### PR TITLE
Update juggler_data_manager.py

### DIFF
--- a/juggler_data_manager.py
+++ b/juggler_data_manager.py
@@ -6,6 +6,7 @@ import pytz
 from datetime import datetime
 import streamlit as st
 from github import Github
+from bs4 import BeautifulSoup
 
 # GitHubへのファイルアップロード関数
 def upload_file_to_github(file_path, repo_name, file_name_in_repo, commit_message, GITHUB_TOKEN):
@@ -29,16 +30,13 @@ def upload_file_to_github(file_path, repo_name, file_name_in_repo, commit_messag
         st.error(f"GitHubへのファイルアップロード中にエラーが発生しました: {e_outer}")
 
 # データ抽出と保存
-def extract_data_and_save_to_csv(html_path, output_csv_path, date):
+def extract_data_and_save_to_csv(html_content, output_csv_path):
     # BeautifulSoupを使ってHTMLからデータを抽出する
-    with open(html_path, "r", encoding="utf-8") as file:
-        html_content = file.read()
-
     soup = BeautifulSoup(html_content, "lxml")
     rows = soup.find_all("tr")[1:]
 
     data = {
-        "台番号": [], "累計スタート": [], "BB回数": [], "RB回数": [], 
+        "台番号": [], "続續スタート": [], "BB回数": [], "RB回数": [], 
         "ART回数": [], "最大持玉": [], "BB確率": [], "RB確率": [], 
         "ART確率": [], "合成確率": []
     }
@@ -47,7 +45,7 @@ def extract_data_and_save_to_csv(html_path, output_csv_path, date):
         cells = row.find_all("td")
         if len(cells) > 1:
             data["台番号"].append(cells[1].get_text())
-            data["累計スタート"].append(cells[2].get_text())
+            data["続續スタート"].append(cells[2].get_text())
             data["BB回数"].append(cells[3].get_text())
             data["RB回数"].append(cells[4].get_text())
             data["ART回数"].append(cells[5].get_text())
@@ -82,8 +80,8 @@ def apply_color_fill_to_excel(excel_path):
     wb.save(excel_path)
 
 # Streamlitアプリケーションのインターフェース
-st.title("🎰 Juggler Data Manager 🎰")
-st.write("このアプリでは、HTMLからデータを抽出し、Excelファイルに保存し、色付けします。")
+st.title("🎮 Juggler Data Manager 🎮")
+st.write("このアプでは、HTMLからデータを抽出し、Excelファイルに保存し、色付けします。")
 
 # GitHubトークンの取得
 GITHUB_TOKEN = st.secrets["github"]["token"]
@@ -92,22 +90,18 @@ GITHUB_TOKEN = st.secrets["github"]["token"]
 japan_time_zone = pytz.timezone('Asia/Tokyo')
 current_date_japan = datetime.now(japan_time_zone)
 
-# HTMLファイルの入力
-uploaded_html = st.file_uploader("HTMLファイルをアップロード", type=["html", "htm", "txt"])
+# HTMLデータの直接貼り付け
+html_content = st.text_area("HTMLデータを貼り付け")
 date_input = st.date_input("日付を選択", current_date_japan)
 
 # ファイルの処理開始ボタン
 if st.button("処理開始"):
-    if uploaded_html:
-        html_path = os.path.join(".", uploaded_html.name)
-        with open(html_path, "wb") as f:
-            f.write(uploaded_html.getbuffer())
-        
+    if html_content:
         output_csv_path = os.path.join(".", f"slot_machine_data_{date_input}.csv")
-        excel_path = "マイジャグラーV_塗りつぶし済み.xlsx"
+        excel_path = "マイジャグラV_塗りつぶし済み.xlsx"
         
         # データ処理とExcelファイル作成
-        df_new = extract_data_and_save_to_csv(html_path, output_csv_path, date_input)
+        df_new = extract_data_and_save_to_csv(html_content, output_csv_path)
         apply_color_fill_to_excel(excel_path)
 
         st.success(f"データ処理が完了し、{excel_path} に保存されました。")
@@ -117,6 +111,21 @@ if st.button("処理開始"):
         commit_message = f"Add data for {date_input}"
         upload_file_to_github(excel_path, repo_name, excel_path, commit_message, GITHUB_TOKEN)
         upload_file_to_github(output_csv_path, repo_name, os.path.basename(output_csv_path), commit_message, GITHUB_TOKEN)
+
+        # データのダウンロード機能
+        st.download_button(
+            label="抽出したCSVファイルをダウンロード",
+            data=open(output_csv_path, "rb").read(),
+            file_name=os.path.basename(output_csv_path),
+            mime="text/csv"
+        )
+
+        st.download_button(
+            label="Excelファイルをダウンロード",
+            data=open(excel_path, "rb").read(),
+            file_name=excel_path,
+            mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        )
 
         # 可視化アプリへのリンク
         st.markdown("[こちらをクリックしてJuggler Data Visualizerへ移動](https://juggler-data-apps-6qz2wrn69bezyvzykh5bdb.streamlit.app/)")


### PR DESCRIPTION
HTMLデータをファイルではなく、テキストエリアに直接貼り付けるオプションを追加しました。
抽出したCSVファイルと色付けされたExcelファイルの両方をダウンロードできるボタンを追加しました。